### PR TITLE
DEVOPS-3254: fix(deployment scheduler): use apps/v1 instead of extenstion/v1beta1 for deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN sudo apt-get update \
 ADD schedule_scaling /root/schedule_scaling
 COPY ./run_missed_jobs.py /root
 RUN chmod a+x /root/run_missed_jobs.py
+# allow us to override pykube.Deployment with the correct api version
+COPY ./cadeployment.py /root/schedule_scaling
 COPY ./startup.sh /root
 RUN chmod a+x /root/startup.sh
 CMD /root/startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,10 @@ RUN sudo apt-get update \
 ADD schedule_scaling /root/schedule_scaling
 COPY ./run_missed_jobs.py /root
 RUN chmod a+x /root/run_missed_jobs.py
-# allow us to override pykube.Deployment with the correct api version
-COPY ./cadeployment.py /root/schedule_scaling
+# allow us to override pykube resources
+COPY ./resources.py /root/schedule_scaling
+ENV PYTHONPATH "${PYTHONPATH}:/root/schedule_scaling"
+
 COPY ./startup.sh /root
 RUN chmod a+x /root/startup.sh
 CMD /root/startup.sh

--- a/cadeployment.py
+++ b/cadeployment.py
@@ -1,7 +1,0 @@
-from pykube import Deployment
-import pykube
-
-# extends pykube.Deployment, overriding version "v1beta1" with "apps/v1"
-class CADeployment(pykube.Deployment):
-
-    version = "apps/v1"

--- a/cadeployment.py
+++ b/cadeployment.py
@@ -1,0 +1,7 @@
+from pykube import Deployment
+import pykube
+
+# extends pykube.Deployment, overriding version "v1beta1" with "apps/v1"
+class CADeployment(pykube.Deployment):
+
+    version = "apps/v1"

--- a/deploy/production/apply/deployment.yaml
+++ b/deploy/production/apply/deployment.yaml
@@ -31,7 +31,7 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "list"]
-- apiGroups: ["extensions"]
+- apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get", "list", "patch"]
 - apiGroups: ["autoscaling", "extensions"]

--- a/resources.py
+++ b/resources.py
@@ -1,0 +1,7 @@
+from pykube import Deployment
+import pykube
+
+# extends pykube.Deployment, overriding version "extensions/v1beta1" with "apps/v1"
+class Deployment(pykube.Deployment):
+
+    version = "apps/v1"

--- a/schedule_scaling/schedule_scaling.py
+++ b/schedule_scaling/schedule_scaling.py
@@ -8,6 +8,7 @@ import pykube
 import re
 import urllib.request
 import boto3
+import cadeployment
 from crontab import CronTab
 
 EXECUTION_TIME = 'datetime.datetime.now().strftime("%d-%m-%Y %H:%M UTC")'
@@ -19,6 +20,8 @@ def create_job_directory():
     if os.path.isdir(temp__dir):
         shutil.rmtree(temp__dir)
     pathlib.Path(temp__dir).mkdir(parents=True, exist_ok=True)
+    # need to copy cadeployment.py to override pykube.Deployment with the correct api version
+    shutil.copyfile('/root/schedule_scaling/cadeployment.py', '/tmp/scaling_jobs/cadeployment.py')
 
 
 def clear_cron():
@@ -53,7 +56,7 @@ def deployments_to_scale():
     scaling_dict = {}
     for namespace in list(pykube.Namespace.objects(api)):
         namespace = str(namespace)
-        for deployment in pykube.Deployment.objects(api).filter(namespace=namespace):
+        for deployment in cadeployment.CADeployment.objects(api).filter(namespace=namespace):
             annotations = deployment.metadata.get('annotations', {})
             f_deployment = str(namespace + '/' + str(deployment))
 

--- a/schedule_scaling/schedule_scaling.py
+++ b/schedule_scaling/schedule_scaling.py
@@ -8,7 +8,7 @@ import pykube
 import re
 import urllib.request
 import boto3
-import cadeployment
+import resources
 from crontab import CronTab
 
 EXECUTION_TIME = 'datetime.datetime.now().strftime("%d-%m-%Y %H:%M UTC")'
@@ -20,9 +20,6 @@ def create_job_directory():
     if os.path.isdir(temp__dir):
         shutil.rmtree(temp__dir)
     pathlib.Path(temp__dir).mkdir(parents=True, exist_ok=True)
-    # need to copy cadeployment.py to override pykube.Deployment with the correct api version
-    shutil.copyfile('/root/schedule_scaling/cadeployment.py', '/tmp/scaling_jobs/cadeployment.py')
-
 
 def clear_cron():
     """ This is needed so that if any one removes his scaling action
@@ -56,7 +53,7 @@ def deployments_to_scale():
     scaling_dict = {}
     for namespace in list(pykube.Namespace.objects(api)):
         namespace = str(namespace)
-        for deployment in cadeployment.CADeployment.objects(api).filter(namespace=namespace):
+        for deployment in resources.Deployment.objects(api).filter(namespace=namespace):
             annotations = deployment.metadata.get('annotations', {})
             f_deployment = str(namespace + '/' + str(deployment))
 

--- a/schedule_scaling/templates/deployment-script.py
+++ b/schedule_scaling/templates/deployment-script.py
@@ -2,6 +2,7 @@ import pykube
 import operator
 import time
 import datetime
+import cadeployment
 
 def get_kube_api():
     try:
@@ -14,7 +15,7 @@ def get_kube_api():
 
 
 api = get_kube_api()
-deployment = pykube.Deployment.objects(api).filter(namespace="%(namespace)s").get(name="%(name)s")
+deployment = cadeployment.CADeployment.objects(api).filter(namespace="%(namespace)s").get(name="%(name)s")
 
 replicas = %(replicas)s
 minReplicas = %(minReplicas)s

--- a/schedule_scaling/templates/deployment-script.py
+++ b/schedule_scaling/templates/deployment-script.py
@@ -2,7 +2,7 @@ import pykube
 import operator
 import time
 import datetime
-import cadeployment
+import resources
 
 def get_kube_api():
     try:
@@ -15,7 +15,7 @@ def get_kube_api():
 
 
 api = get_kube_api()
-deployment = cadeployment.CADeployment.objects(api).filter(namespace="%(namespace)s").get(name="%(name)s")
+deployment = resources.Deployment.objects(api).filter(namespace="%(namespace)s").get(name="%(name)s")
 
 replicas = %(replicas)s
 minReplicas = %(minReplicas)s


### PR DESCRIPTION
And fix rbac api version.

Tested in minikube - brings casebook web/worker up and down fine.