### PR TITLE
Handle missed schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ When an `HorizontalPodAutoscaler` is managing the `Deployment`, it will ignore t
 
 In order for the `HorizontalPodAutoscaler` to be detected, it must be called with the same name as the `Deployment` that manages.
 
+## Configuration
+
+Configuration is done using environment variables:
+
+* `LOG_LEVEL` - change default log level, use `debug` to increase verbosity
+
+* `STARTUP_SCHEDULE_WINDOW_SECONDS` - a number of seconds to look back during the first schedule after startup, by setting this to `900` you'll make cron-schedule-scaler execute any configured schedules that happened up to 15 minutes before - this is designed to protect against missing schedules due to kube-schedule-scaler downtime (e.g. restarts, deployments, etc)
+
 ## Debugging
 
 If your scaling action has not been executed for some reason, you can check with the steps below:

--- a/schedule_scaling/main.py
+++ b/schedule_scaling/main.py
@@ -205,6 +205,14 @@ def scale_hpa(name, namespace, min_replicas, max_replicas):
 if __name__ == "__main__":
     logging.info("Main loop started")
     last_process_time = round_to_minute(datetime.now())
+
+    startup_schedule_window_sec = os.environ.get("STARTUP_SCHEDULE_WINDOW_SECONDS")
+    if startup_schedule_window_sec:
+        logging.info(
+            "Running the first loop executing schedules old up to %s seconds",
+            startup_schedule_window_sec)
+        last_process_time = last_process_time - timedelta(seconds=int(startup_schedule_window_sec))
+
     while True:
         logging.debug("Waiting until the next minute")
         sleep(get_wait_sec())


### PR DESCRIPTION
Hi!

This PR adds handling for two types of missed schedules:
* schedules missed due to kube-schedule-scaler being down (like schedules that happen at the same time as a container restart, a container deployment, a cloud preemptible instance release, and so on)
* schedules missed because of main loop executing for longer than 1 minute (rather theoretical, but who knows... maybe with a huge number of deployments it could happen?)

New feature is disabled by default and default behavior should be almost the same as before. I tested it manually on 1.21 cluster, I can test on other versions in minikube (and add e2e tests I've mentioned in other PR as well).