### PR TITLE
Replace pykube with pykube-ng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8-alpine
 
-RUN pip install --no-cache-dir pykube croniter
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
 RUN adduser -u 1000 -D app && \
     mkdir /app && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM python:3.8-alpine
-
-RUN apk add gcc libc-dev
+FROM python:3.10-alpine
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.txt

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -33,10 +33,12 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["get", "list", "patch"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments/scale"]
+  verbs: ["patch"]
 - apiGroups: ["autoscaling", "extensions"]
-  resources:
-    - horizontalpodautoscalers
+  resources: ["horizontalpodautoscalers"]
   verbs: ["get", "list", "patch"]
 ---
 apiVersion: apps/v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pykube-ng==21.10.0
+croniter==1.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pykube-ng==21.10.0
-croniter==1.0.15
+pykube-ng==22.1.0
+croniter==1.3.5

--- a/schedule_scaling/main.py
+++ b/schedule_scaling/main.py
@@ -120,9 +120,22 @@ def scale_deployment(name, namespace, replicas):
 
     try:
         try:
-            deployment.patch({"spec": {"replicas": replicas}}, subresource="scale")
-        finally:
-            deployment.reload()  # reload to fetch whole updated Deployment
+            try:
+                deployment.patch({"spec": {"replicas": replicas}}, subresource="scale")
+            finally:
+                deployment.reload()  # reload to fetch whole updated Deployment
+        except pykube.exceptions.HTTPError as e:
+            # XXX: In previous version deployment.update() was always used. It was unnecessary, but after moving to a
+            # subresource patch we've lost backward compatibility, as previous RBAC "patch" on "deployments" doesn't
+            # work. So if we get an 403 pring a warning and try again, this time with full resource update.
+            if e.code == 403:
+                logging.warning(
+                        "Failed to apply patch on a 'scale' subresource, failing back to a full update. "
+                        "Consider upgrading RBAC deployment.")
+                deployment.replicas = replicas
+                deployment.update()
+            else:
+                raise
         logging.info("Deployment %s/%s scaled to %s replicas", namespace, name, replicas)
     except pykube.exceptions.HTTPError as err:
         logging.error("Exception raised while updating deployment %s/%s", namespace, name)

--- a/schedule_scaling/main.py
+++ b/schedule_scaling/main.py
@@ -19,13 +19,7 @@ logging.basicConfig(
 
 def get_kube_api():
     """ Initiating the API from Service Account or when running locally from ~/.kube/config """
-    try:
-        config = pykube.KubeConfig.from_service_account()
-    except FileNotFoundError:
-        # local testing
-        config = pykube.KubeConfig.from_file(
-            os.path.expanduser("~/.kube/config"))
-    return pykube.HTTPClient(config)
+    return pykube.HTTPClient(pykube.KubeConfig.from_env())
 
 
 api = get_kube_api()

--- a/schedule_scaling/main.py
+++ b/schedule_scaling/main.py
@@ -117,10 +117,12 @@ def scale_deployment(name, namespace, replicas):
 
     if replicas is None or replicas == deployment.replicas:
         return
-    deployment.replicas = replicas
 
     try:
-        deployment.update()
+        try:
+            deployment.patch({"spec": {"replicas": replicas}}, subresource="scale")
+        finally:
+            deployment.reload()  # reload to fetch whole updated Deployment
         logging.info("Deployment %s/%s scaled to %s replicas", namespace, name, replicas)
     except pykube.exceptions.HTTPError as err:
         logging.error("Exception raised while updating deployment %s/%s", namespace, name)

--- a/schedule_scaling/main.py
+++ b/schedule_scaling/main.py
@@ -8,7 +8,6 @@ from time import sleep
 
 import pykube
 from croniter import croniter
-from resources import Deployment
 
 
 logging.basicConfig(
@@ -38,7 +37,7 @@ def deployments_to_scale():
     scaling_dict = {}
     for namespace in list(pykube.Namespace.objects(api)):
         namespace = str(namespace)
-        for deployment in Deployment.objects(api).filter(namespace=namespace):
+        for deployment in pykube.Deployment.objects(api).filter(namespace=namespace):
             annotations = deployment.metadata.get("annotations", {})
             f_deployment = str(namespace + "/" + str(deployment))
 
@@ -116,7 +115,7 @@ def process_deployment(deployment, schedules):
 def scale_deployment(name, namespace, replicas):
     """ Scale the deployment to the given number of replicas """
     try:
-        deployment = Deployment.objects(api).filter(
+        deployment = pykube.Deployment.objects(api).filter(
             namespace=namespace).get(name=name)
     except pykube.exceptions.ObjectDoesNotExist:
         logging.warning("Deployment %s/%s does not exist", namespace, name)

--- a/schedule_scaling/resources.py
+++ b/schedule_scaling/resources.py
@@ -1,6 +1,0 @@
-""" Overrides of Kubernetes resource classes from pykube """
-import pykube
-
-class Deployment(pykube.Deployment):
-    """ Extends pykube.Deployment, overriding k8s apiVersion 'extensions/v1beta1' with 'apps/v1' """
-    version = "apps/v1"


### PR DESCRIPTION
Based on #4, replaces the abandoned pykube with pykube-ng, and updates dependencies and python version to latest