### PR TITLE
Fix stale serviceaccount tokens

### DIFF
--- a/schedule_scaling/main.py
+++ b/schedule_scaling/main.py
@@ -23,9 +23,6 @@ def get_kube_api():
     return pykube.HTTPClient(pykube.KubeConfig.from_env())
 
 
-api = get_kube_api()
-
-
 def deployments_to_scale():
     """ Getting the deployments configured for schedule scaling """
     deployments = []
@@ -193,6 +190,9 @@ def scale_hpa(name, namespace, min_replicas, max_replicas):
 if __name__ == "__main__":
     logging.info("Main loop started")
     while True:
+        global api
+        api = get_kube_api()
+
         logging.debug("Waiting until the next minute")
         sleep(get_wait_sec())
         logging.debug("Getting deployments")


### PR DESCRIPTION
Kubernetes version 1.21 graduated BoundServiceAccountTokenVolume feature
to beta and enabled it by default. This feature improves security of
service account tokens by requiring a one hour expiry time, over the
previous default of no expiration. This means that applications that do
not refetch service account tokens periodically will receive an HTTP 401
unauthorized error response on requests to Kubernetes API server with
expired tokens

https://github.com/kubernetes/enhancements/issues/542

This commit forces kube-schedule-scaler to refresh token every minute,
and acts as workaround at least until pykube-ng implements automatic
token renewal.